### PR TITLE
fix: use file-truename to get modification time

### DIFF
--- a/mise.el
+++ b/mise.el
@@ -215,7 +215,7 @@ Generate new key when mise configs files modified."
   (let* ((configs (mise--detect-configs))
          (mdtime (mapcar (##number-to-string
                           (time-convert (file-attribute-modification-time
-                                         (file-attributes %))
+                                         (file-attributes (file-truename %)))
                                         'integer))
                          configs)))
     (concat env-dir "\0" (md5 (string-join (append configs mdtime))))))


### PR DESCRIPTION
 The mise--cache-key function was previously using file-attributes directly on configuration
  file paths. When these paths are symbolic links (e.g., in a setup managed by stow), this
  resulted in using the modification time of the symlink itself, not the target file it points
   to.

  This caused incorrect cache key generation, as the cache was not invalidated when the
  underlying configuration file was modified.

  This commit fixes the issue by wrapping the file path in file-truename before calling
  file-attributes. This ensures that we always resolve symbolic links to their target files
  and use the modification time of the actual file content, allowing mise.el to work
  correctly with symlinked configurations.
